### PR TITLE
Add Record iterator to Series

### DIFF
--- a/src/criteria.rs
+++ b/src/criteria.rs
@@ -80,12 +80,9 @@ pub struct Tags {
 impl Criteria for Tags {
     fn apply<T: Recordable>(&self, record: &T) -> bool {
         let record_tags = record.tags();
-        let mismatched_tags: Vec<bool> = self.tags
+        self.tags
             .iter()
-            .map(|v| record_tags.contains(v))
-            .filter(|v| !v)
-            .collect();
-        mismatched_tags.len() == 0
+            .all(|v| record_tags.contains(v))
     }
 }
 


### PR DESCRIPTION
This PR adds the `records` method you apparently wanted.

Apart from fixing the type signature, I made one modification: instead of cloning the data, `Series::records` now _refers_ to the records in the `Series`. The 'old' behavior can easily be achieved at the call-site (e.g., by invoking `Iterator::cloned` on the result) whereas the other way around would not be possible. Still, if that is not what you wanted, let me know and I'll modify my PR.

The new test case I added is modeled on those you provide. It simply establishes that the contents of the iterator are indeed the same as those returned by the `Series::all_records` method.